### PR TITLE
Finishing transition to LMDB (Rayon, Async, Zstd, Dynamic resizing)

### DIFF
--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1,12 +1,14 @@
 use byteorder::LE;
+use chunks::Zstd;
 use deepsize::DeepSizeOf;
 use futures::FutureExt;
-use heed::types::{Bytes, U64};
+use heed::types::U64;
 use heed::{Env as LMDBDatabase, EnvFlags, EnvOpenOptions};
 use moka::notification::{ListenerFuture, RemovalCause};
+use rayon::{ThreadPool, ThreadPoolBuilder};
 use std::env;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use tokio::fs;
 use tracing::{debug, info, trace};
@@ -19,6 +21,10 @@ pub mod chunks;
 
 // MDBX constants
 const LMDB_PAGE_SIZE: usize = 50 * 1024usize.pow(3); // 50GiB
+const LMDB_MAX_DBS: u32 = 10;
+
+// Database threadpool
+static LMDB_THREADPOOL: OnceLock<ThreadPool> = OnceLock::new();
 
 /// Global database structure
 ///
@@ -70,7 +76,7 @@ pub async fn start_database() -> Result<Database, Error> {
     let mut opts = EnvOpenOptions::new();
     opts.max_readers(num_cpus::get() as u32)
         .map_size(LMDB_PAGE_SIZE)
-        .max_dbs(num_cpus::get() as u32 *2);
+        .max_dbs(LMDB_MAX_DBS);
 
     // Open database (This operation is safe as we assume no other process touched the database)
     let lmdb = unsafe {
@@ -79,14 +85,19 @@ pub async fn start_database() -> Result<Database, Error> {
             .expect("Unable to open LMDB environment located at {world_path:?}")
     };
 
+    // Start database threadpool
+    LMDB_THREADPOOL.get_or_init(|| {
+        ThreadPoolBuilder::new().num_threads(num_cpus::get() / 2).build().unwrap()
+    });
+    
     // Check if database is built. Otherwise, initialize it
     let mut rw_tx = lmdb.write_txn().unwrap();
     if lmdb
-        .open_database::<U64<LE>, Bytes>(&rw_tx, Some("chunks"))
+        .open_database::<U64<LE>, Zstd<Chunk>>(&rw_tx, Some("chunks"))
         .unwrap()
         .is_none()
     {
-        lmdb.create_database::<U64<LE>, Bytes>(&mut rw_tx, Some("chunks"))
+        lmdb.create_database::<U64<LE>, Zstd<Chunk>>(&mut rw_tx, Some("chunks"))
             .expect("Unable to create database");
     }
     // `entities` table to be added, but needs the type to do so

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,7 @@ async fn start_server() -> Result<()> {
 
     if env::args().any(|arg| arg == "--import") {
         // world::importing::import_regions(state.clone()).await?;
-        rayon::ThreadPoolBuilder::new().num_threads(num_cpus::get() * 2).build_global().expect("Failed to build rayon thread pool");
+        rayon::ThreadPoolBuilder::new().num_threads(num_cpus::get()).build_global().expect("Failed to build rayon thread pool");
         world::importing::import_regions(state.clone()).await?;
         exit(0);
     }
@@ -117,5 +117,3 @@ async fn create_state(tcp_listener: TcpListener) -> Result<GlobalState> {
         server_stream: tcp_listener,
     }))
 }
-
-

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -115,5 +115,3 @@ impl From<Error> for std::io::ErrorKind {
         std::io::ErrorKind::Other
     }
 }
-
-


### PR DESCRIPTION
> [!IMPORTANT]
> **This PR completes the transition from RocksDB to LMDB** for FerrumC, making it fully functional. However, further optimizations are still necessary to unlock its full performance.

Closes: #8 

The PR includes the following changes:

* Implemented Zstd compression (level 6) over a `Zstd<T>`  structure, simplifying the code and enabling future optimizations.
* Created a dedicated rayon threadpool (`LMDB_THREADPOOL`) or LMDB, utilizing half of the available CPU cores.
* Cleaned up imports for better organization.
* Replaced `tokio::task::spawn_blocking` with the `spawn_blocking_db` function, which leverages the rayon threadpool.
* Implemented a `close` function to the database
* Updated all chunks table opens to use `Zstd<Chunk>` instead of `Bytes`
* Implemented dynamic page resizing, starting at 100MB and increasing by 200MB when the environment size limit is reached, with a warning emitted upon each resize.

**Additional testing by at least one other contributor is required**. My testing has been successful, with a map imported and explored without issues.